### PR TITLE
Fluorescence top model with attention

### DIFF
--- a/tape/models/modeling_unirep.py
+++ b/tape/models/modeling_unirep.py
@@ -172,11 +172,13 @@ class UniRepForLM(UniRepAbstractModel):
         outputs = (prediction_scores,) + outputs[2:]
 
         if targets is not None:
+            # the changes will go here
             targets = targets[:, 1:]
             prediction_scores = prediction_scores[:, :-1]
             loss_fct = nn.CrossEntropyLoss(ignore_index=-1)
             lm_loss = loss_fct(
                 prediction_scores.view(-1, self.config.vocab_size), targets.view(-1))
+
             outputs = (lm_loss,) + outputs
 
         # (loss), prediction_scores, (hidden_states)

--- a/tape/models/modeling_unirep.py
+++ b/tape/models/modeling_unirep.py
@@ -173,6 +173,7 @@ class UniRepForLM(UniRepAbstractModel):
 
         if targets is not None:
             # the changes will go here
+            # the second round of changes
             targets = targets[:, 1:]
             prediction_scores = prediction_scores[:, :-1]
             loss_fct = nn.CrossEntropyLoss(ignore_index=-1)


### PR DESCRIPTION
This merge is only applicable for Bert. It was successful in training to the published Spearman's coefficient of 0.68 (rounded from 0.6755) and so would appear to be successful. 

Could be used in other models by calling  ValuePredictionHeadWithAttention and also note didn't use pooling in the same way and dropped the cls/sep token reps.

Used LayerNorm as per original Tensorflow implementation: https://github.com/songlab-cal/tape-neurips2019/blob/3f55c784750207d28327ac69c39f892abf548c06/tape/task_models/ComputeClassVector.py#L10 Could also consider weight_norm or some other form. 
